### PR TITLE
Patch issue #1

### DIFF
--- a/com_zimbra_converse/converse_zimlet.js
+++ b/com_zimbra_converse/converse_zimlet.js
@@ -21,11 +21,13 @@ var ConverseZimlet = com_zimbra_converse_HandlerObject;
  
 ConverseZimlet.prototype.init = function () {
 	this._makeSpaceForConverseBar();
+	require(['converse'], function (converse) {
 		converse.initialize({
 			prebind: false,
 			bosh_service_url: "https://192.168.1.17/http-bind",
 			show_controlbox_by_default:true,
 		});
+	});
 };
 
 /*


### PR DESCRIPTION
This PR fixes #1.
The "ReferenceError : converse is not defined" error won't appear anymore on Zimbra 8.7 loading.